### PR TITLE
fix: sync electrical box prop with networked scene

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -17,7 +17,7 @@ end
 
 local function createElectricalBox()
     lib.requestModel(`tr_prop_tr_elecbox_01a`)
-    electricalBoxEntity = CreateObject(`tr_prop_tr_elecbox_01a`, sharedConfig.electrical.x, sharedConfig.electrical.y, sharedConfig.electrical.z, false, false, false)
+    electricalBoxEntity = CreateObjectNoOffset(joaat("tr_prop_tr_elecbox_01a"), sharedConfig.electrical.x, sharedConfig.electrical.y, sharedConfig.electrical.z, true, true, false)
     SetModelAsNoLongerNeeded(`tr_prop_tr_elecbox_01a`)
     while not DoesEntityExist(electricalBoxEntity) do
         Wait(0)


### PR DESCRIPTION
## Description

change CreateObject native to CreateObjectNoOffset so when the NetworkScene is played the prop is correctly synced and doesn't look weird.

- [X ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
